### PR TITLE
Update README.md  python example

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ from autogen_agentchat.agents import AssistantAgent
 from autogen_agentchat.ui import Console
 from autogen_agentchat.conditions import TextMentionTermination
 from autogen_agentchat.teams import RoundRobinGroupChat
-from autogen_ext.models import OpenAIChatCompletionClient
+from autogen_ext.models.openai import OpenAIChatCompletionClient
 
 # Define a tool
 async def get_weather(city: str) -> str:


### PR DESCRIPTION
Update the Python example in the readme to import OpenAIChatCompletionClient from the new path
This change relates to: https://github.com/microsoft/autogen/pull/4601

## Why are these changes needed?
Currently the example in the readme fails with this error:
Currently, the example fails with this error:
ImportError: cannot import name 'OpenAIChatCompletionClient' from 'autogen_ext.models' (unknown location)


## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
